### PR TITLE
support alpha channel for 2x 3x models

### DIFF
--- a/src/realesrgan.h
+++ b/src/realesrgan.h
@@ -34,6 +34,8 @@ private:
     ncnn::Net net;
     ncnn::Pipeline* realesrgan_preproc;
     ncnn::Pipeline* realesrgan_postproc;
+    ncnn::Layer* bicubic_2x;
+    ncnn::Layer* bicubic_3x;
     ncnn::Layer* bicubic_4x;
     bool tta_mode;
 };


### PR DESCRIPTION
目前使用real-esrganv2 2x模型放大带alpha通道的png，会输出全透明的结果。
此pr对此问题进行了修复