### PR TITLE
fix MinGW compilation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -274,6 +274,10 @@ compile_shader(realesrgan_postproc_tta.comp)
 
 add_custom_target(generate-spirv DEPENDS ${SHADER_SPV_HEX_FILES})
 
+if(MINGW)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -municode")
+endif()
+
 add_executable(realesrgan-ncnn-vulkan main.cpp realesrgan.cpp)
 
 add_dependencies(realesrgan-ncnn-vulkan generate-spirv)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -700,12 +700,12 @@ int main(int argc, char** argv)
 
     if (modelname == PATHSTR("realesr-animevideov3"))
     {
-        swprintf(parampath, 256, L"%s/%s-x%s.param", model.c_str(), modelname.c_str(), std::to_string(scale));
-        swprintf(modelpath, 256, L"%s/%s-x%s.bin", model.c_str(), modelname.c_str(), std::to_string(scale));
+        swprintf(parampath, 256, L"%ls/%ls-x%d.param", model.c_str(), modelname.c_str(), scale);
+        swprintf(modelpath, 256, L"%ls/%ls-x%d.bin", model.c_str(), modelname.c_str(), scale);
     }
     else{
-        swprintf(parampath, 256, L"%s/%s.param", model.c_str(), modelname.c_str());
-        swprintf(modelpath, 256, L"%s/%s.bin", model.c_str(), modelname.c_str());
+        swprintf(parampath, 256, L"%ls/%ls.param", model.c_str(), modelname.c_str());
+        swprintf(modelpath, 256, L"%ls/%ls.bin", model.c_str(), modelname.c_str());
     }
 
 #else


### PR DESCRIPTION
MinGW expects `main()` without the `-municode` option, but the code uses `wmain()`. This results in an error:

```
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/12.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/12.2.0/../../../../lib/libmingw32.a(lib64_libmingw32_a-crt0_c.o): in function `main':
C:/M/mingw-w64-crt-git/src/mingw-w64/mingw-w64-crt/crt/crt0_c.c:18: undefined reference to `WinMain'
collect2.exe: error: ld returned 1 exit status
mingw32-make[2]: *** [CMakeFiles\realesrgan-ncnn-vulkan.dir\build.make:136: realesrgan-ncnn-vulkan.exe] Error 1
mingw32-make[1]: *** [CMakeFiles\Makefile2:313: CMakeFiles/realesrgan-ncnn-vulkan.dir/all] Error 2
mingw32-make: *** [Makefile:148: all] Error 2
```